### PR TITLE
Use 'expo-crypto' for sha256 digest instead of isomorphic-webcrypto.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @digitalcredentials/jsonld-signatures ChangeLog
 
+## 12.0.0 -
+
+### Changed
+- **BREAKING**: Now uses `expo-crypto` for React Native sha256 digest hashing, instead of 
+  `@sphereon/isomorphic-webcrypto@2.5.0-unstable.0`.
+  - **IMPORTANT**: This means that IF you're using this library inside a React Native project, you MUST include `expo-crypto`
+    in your project's `dependencies`.
+
 ## 11.0.0 - 2024-08-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,22 +14,8 @@
 - [Commercial Support](#commercial-support)
 - [License](#license)
 
-## Version Compatibility
-
 (Forked from [`jsonld-signatures` v9.0.0](https://github.com/digitalbazaar/jsonld-signatures)
-to provide TypeScript compatibility.)
-
-`jsonld-signatures` **v9.0** is compatible with the following signature suites:
-
-* [`ed25519-signature-2020`](https://github.com/digitalcredentials/ed25519-signature-2020)
-  `>= 2.1.0`.
-
-and the following related libraries:
-
-* `crypto-ld` `>= 5.0.0` (and related key crypto suites such as 
-  [`ed25519-verification-key-2020`](https://github.com/digitalbazaar/ed25519-verification-key-2020)
-  `>= 2.1.0`).
-* `@digitalcredentials/vc` `>= 1.0`
+to provide TypeScript, Jest, and React Native compatibility.)
 
 ## Background
 
@@ -61,7 +47,7 @@ document.
 One common use case for creating these signatures is for use with 
 [Verifiable Credentials](https://w3c.github.io/vc-data-model) (VCs). If you're 
 working with those, you should use a higher-level library that's specifically
-made for that purpose, such as [`@digitalcredentials/vc`](https://github.com/digitalcredentials/vc-js).
+made for that purpose, such as [`@digitalcredentials/vc`](https://github.com/digitalcredentials/vc).
 (Incidentally, `vc-js` uses this library, `jsonld-signatures`, under the hood.)
 
 ## Security
@@ -111,7 +97,22 @@ npm install
 
 ## Usage
 
-`jsonld-signatures` (version `8.x` and above) is not meant for standalone use.
+### React Native Usage
+
+This library depends on `expo-crypto` when used inside React Native projects.
+That means you must add `expo-crypto` to your project's dependencies.
+
+Sample `package.json`:
+
+```
+  "dependencies": {
+    "expo-crypto": "~12.8.0"
+  }
+```
+
+### Node.js and Browser Usage
+
+`jsonld-signatures` (version `12.x` and above) is not meant for standalone use.
 Instead, it's generally used through an individual _crypto suite_.
 For detailed usage instructions, see the READMEs of the supported suites:
 
@@ -136,13 +137,6 @@ common. You'll need to:
   section of `crypto-ld` documentation.
 * Set up your `documentLoader` to fetch contexts and documents securely.
 * Lastly, perform the `jsigs.sign()` or `jsigs.verify()` operations.
-
-### Node.js Native Canonize Bindings
-
-Specialized use cases may wish to use the native canonize bindings. This mode
-can be enabled by setting the `useNativeCanonize` option to `true`. See the
-[jsonld.js notes](https://github.com/digitalbazaar/jsonld.js#nodejs-native-canonize-bindings)
-on this feature and note you should benchmark performance before using it.
 
 ## Contribute
 

--- a/lib/sha256digest-reactnative.js
+++ b/lib/sha256digest-reactnative.js
@@ -1,9 +1,10 @@
 /*
+ * Copyright (c) 2025 Digital Credentials Consortium - React Native addition.
  * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
-const crypto = require('@sphereon/isomorphic-webcrypto');
+import * as Crypto from 'expo-crypto';
 require('fast-text-encoding');
 
 module.exports = {
@@ -17,7 +18,6 @@ module.exports = {
   async sha256digest({string}) {
     const bytes = new TextEncoder().encode(string);
     return new Uint8Array(
-      await crypto.subtle.digest({name: 'SHA-256'}, bytes)
-    );
+      await Crypto.digest(Crypto.CryptoDigestAlgorithm.SHA256, bytes));
   }
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@digitalcredentials/jsonld": "^9.0.0",
     "@digitalbazaar/security-context": "^1.0.0",
-    "@sphereon/isomorphic-webcrypto": "^2.5.0-unstable.0",
     "fast-text-encoding": "^1.0.3",
     "serialize-error": "^8.0.1"
   },
@@ -67,8 +66,9 @@
   "browser": {
     "crypto": false,
     "./lib/sha256digest.js": "./lib/sha256digest-browser.js",
+    "./lib/sha256digest-reactnative.js": false,
     "fast-text-encoding": false,
-    "@sphereon/isomorphic-webcrypto": false
+    "expo-crypto": false
   },
   "react-native": {
     "crypto": false,


### PR DESCRIPTION
Addresses issue https://github.com/digitalcredentials/learner-credential-wallet/issues/638